### PR TITLE
docker: fix gracefull shutdown of all containers

### DIFF
--- a/docker/simnet/bitcoin-cash/Dockerfile
+++ b/docker/simnet/bitcoin-cash/Dockerfile
@@ -43,4 +43,6 @@ COPY bitcoin.simnet.$ROLE.conf /root/default/bitcoin.conf
 # starting bitcoin cash daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/bitcoin-cash/entrypoint.sh
+++ b/docker/simnet/bitcoin-cash/entrypoint.sh
@@ -26,4 +26,6 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="-externalip=$EXTERNAL_IP"
 fi
 
-bitcoin-cashd $EXTERNAL_IP_OPT
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec bitcoin-cashd $EXTERNAL_IP_OPT

--- a/docker/simnet/bitcoin-lightning-helper/Dockerfile
+++ b/docker/simnet/bitcoin-lightning-helper/Dockerfile
@@ -27,4 +27,6 @@ RUN pip install --no-cache-dir Flask
 
 COPY http-server.py /
 
-ENTRYPOINT python http-server.py
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]ython http-server.py

--- a/docker/simnet/bitcoin-lightning/Dockerfile
+++ b/docker/simnet/bitcoin-lightning/Dockerfile
@@ -44,4 +44,6 @@ COPY bitcoin-lightning.simnet.$ROLE.conf /root/default/lnd.conf
 # starting bitcoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/bitcoin-lightning/entrypoint.sh
+++ b/docker/simnet/bitcoin-lightning/entrypoint.sh
@@ -25,4 +25,6 @@ if [ ! -z $EXTERNAL_IP ]; then
     EXTERNAL_IP_OPT="--externalip=$EXTERNAL_IP"
 fi
 
-lnd $EXTERNAL_IP_OPT
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec lnd $EXTERNAL_IP_OPT

--- a/docker/simnet/bitcoin/Dockerfile
+++ b/docker/simnet/bitcoin/Dockerfile
@@ -45,4 +45,6 @@ COPY bitcoin.simnet.$ROLE.conf /root/default/bitcoin.conf
 # starting bitcoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/bitcoin/entrypoint.sh
+++ b/docker/simnet/bitcoin/entrypoint.sh
@@ -26,4 +26,6 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="-externalip=$EXTERNAL_IP"
 fi
 
-bitcoind $EXTERNAL_IP_OPT
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec bitcoind $EXTERNAL_IP_OPT

--- a/docker/simnet/blocks-generator/Dockerfile
+++ b/docker/simnet/blocks-generator/Dockerfile
@@ -46,4 +46,6 @@ COPY --from=builder litecoin-cli /usr/local/bin/
 # Entrypoint script used for periodically blocks generation
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/blocks-generator/entrypoint.sh
+++ b/docker/simnet/blocks-generator/entrypoint.sh
@@ -42,6 +42,16 @@ bitcoin-cash-cli $BCH_OPTS generate 100
 dash-cli $DASH_OPTS generate 100
 litecoin-cli $LTC_OPTS generate 100
 
+# Proper way to catch shutdown signal and stop infinite loop. In this
+# solution we consider blockchains' cli runs are not long running process
+# so we need to stop sleep only.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+shutdown() {
+    kill -s SIGTERM $!
+    exit 0
+}
+trap shutdown SIGINT SIGTERM
+
 # Periodically block generation.
 while true
 do
@@ -52,5 +62,6 @@ do
     litecoin-cli $LTC_OPTS generate 1
 
     # Wait for next period.
-    sleep $PERIOD
+    sleep $PERIOD &
+    wait $!
 done

--- a/docker/simnet/connector/Dockerfile
+++ b/docker/simnet/connector/Dockerfile
@@ -26,4 +26,6 @@ COPY connector.simnet.$ROLE.conf /root/default/connector.conf
 # starting dash daemon
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/connector/entrypoint.sh
+++ b/docker/simnet/connector/entrypoint.sh
@@ -18,4 +18,6 @@ fi
 echo "Restoring default config"
 cp $DEFAULTS_DIR/connector.conf $CONFIG
 
-connector --config /root/.connector/connector.conf
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec connector --config /root/.connector/connector.conf

--- a/docker/simnet/dash/Dockerfile
+++ b/docker/simnet/dash/Dockerfile
@@ -42,4 +42,6 @@ COPY dash.simnet.$ROLE.conf /root/default/dash.conf
 # starting dash daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/dash/entrypoint.sh
+++ b/docker/simnet/dash/entrypoint.sh
@@ -26,4 +26,6 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="-externalip=$EXTERNAL_IP"
 fi
 
-dashd $EXTERNAL_IP_OPT
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec dashd $EXTERNAL_IP_OPT

--- a/docker/simnet/docker-compose.yml
+++ b/docker/simnet/docker-compose.yml
@@ -30,6 +30,9 @@ x-defaults:
   # Restart on exit.
   restart: always
 
+  # Wait for one minute for gracefull shutdown
+  stop_grace_period: 1m
+
 
 
 services:

--- a/docker/simnet/ethereum-bootnode/Dockerfile
+++ b/docker/simnet/ethereum-bootnode/Dockerfile
@@ -23,4 +23,6 @@ COPY --from=builder /ethereum/build/bin/bootnode /usr/local/bin/
 # starting bootnode daemon
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/ethereum-bootnode/entrypoint.sh
+++ b/docker/simnet/ethereum-bootnode/entrypoint.sh
@@ -43,4 +43,6 @@ fi
 # Start bootnode with computed key file on defined bind address and
 # with optional nat external IP.
 echo "Starting bootnode"
-bootnode --nodekey=$KEY_FILE --addr=$BIND_ADDR $EXTERNAL_IP_OPT
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec bootnode --nodekey=$KEY_FILE --addr=$BIND_ADDR $EXTERNAL_IP_OPT

--- a/docker/simnet/ethereum/Dockerfile
+++ b/docker/simnet/ethereum/Dockerfile
@@ -43,4 +43,6 @@ COPY genesis.json /root/default/
 # starting bitcoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/ethereum/entrypoint.sh
+++ b/docker/simnet/ethereum/entrypoint.sh
@@ -70,7 +70,9 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="--nat extip:$EXTERNAL_IP"
 fi
 
-geth \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec geth \
 --datadir $DATA_DIR \
 --config $CONFIG \
 --bootnodes `cat $ENODE` \

--- a/docker/simnet/litecoin/Dockerfile
+++ b/docker/simnet/litecoin/Dockerfile
@@ -42,4 +42,6 @@ COPY litecoin.simnet.$ROLE.conf /root/default/litecoin.conf
 # starting litecoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/simnet/litecoin/entrypoint.sh
+++ b/docker/simnet/litecoin/entrypoint.sh
@@ -26,4 +26,6 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="-externalip=$EXTERNAL_IP"
 fi
 
-litecoind $EXTERNAL_IP_OPT
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec litecoind $EXTERNAL_IP_OPT

--- a/docker/testnet/bitcoin-cash/Dockerfile
+++ b/docker/testnet/bitcoin-cash/Dockerfile
@@ -34,4 +34,6 @@ COPY bitcoin-cash.testnet.conf /root/default/bitcoin.conf
 # starting bitcoin cash daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/testnet/bitcoin-cash/entrypoint.sh
+++ b/docker/testnet/bitcoin-cash/entrypoint.sh
@@ -27,5 +27,7 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="-externalip=$EXTERNAL_IP"
 fi
 
-bitcoin-cashd $EXTERNAL_IP_OPT \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec bitcoin-cashd $EXTERNAL_IP_OPT \
 --rpcauth=$BITCOIN_CASH_RPC_AUTH

--- a/docker/testnet/bitcoin-lightning/Dockerfile
+++ b/docker/testnet/bitcoin-lightning/Dockerfile
@@ -35,4 +35,6 @@ COPY bitcoin-lightning.testnet.conf /root/default/lnd.conf
 # starting bitcoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/testnet/bitcoin-lightning/entrypoint.sh
+++ b/docker/testnet/bitcoin-lightning/entrypoint.sh
@@ -28,6 +28,8 @@ fi
 
 RPC_USER_OPT="--bitcoind.rpcuser="
 
-lnd $EXTERNAL_IP_OPT \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec lnd $EXTERNAL_IP_OPT \
 --bitcoind.rpcuser=$BITCOIN_RPC_USER \
 --bitcoind.rpcpass=$BITCOIN_RPC_PASSWORD

--- a/docker/testnet/bitcoin-neutrino/Dockerfile
+++ b/docker/testnet/bitcoin-neutrino/Dockerfile
@@ -34,4 +34,6 @@ COPY bitcoin-neutrino.testnet.conf /root/default/btcd.conf
 # starting bitcoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/testnet/bitcoin-neutrino/entrypoint.sh
+++ b/docker/testnet/bitcoin-neutrino/entrypoint.sh
@@ -28,6 +28,8 @@ fi
 
 RPC_USER_OPT="--bitcoind.rpcuser="
 
-btcd $EXTERNAL_IP_OPT \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec btcd $EXTERNAL_IP_OPT \
 --rpcuser=$BITCOIN_NEUTRINO_RPC_USER
 --rpcpass=$BITCOIN_NEUTRINO_RPC_PASSWORD

--- a/docker/testnet/bitcoin/Dockerfile
+++ b/docker/testnet/bitcoin/Dockerfile
@@ -36,4 +36,6 @@ COPY bitcoin.testnet.conf /root/default/bitcoin.conf
 # starting bitcoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/testnet/bitcoin/entrypoint.sh
+++ b/docker/testnet/bitcoin/entrypoint.sh
@@ -27,5 +27,7 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="-externalip=$EXTERNAL_IP"
 fi
 
-bitcoind $EXTERNAL_IP_OPT \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec bitcoind $EXTERNAL_IP_OPT \
 --rpcauth=$BITCOIN_RPC_AUTH

--- a/docker/testnet/connector/Dockerfile
+++ b/docker/testnet/connector/Dockerfile
@@ -34,4 +34,6 @@ COPY connector.testnet.conf /root/default/connector.conf
 # starting dash daemon
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/testnet/connector/entrypoint.sh
+++ b/docker/testnet/connector/entrypoint.sh
@@ -26,7 +26,9 @@ if [ $EXCHANGE_DISABLED -eq 1 ]; then
     EXCHANGE_DISABLED_OPT="--enginedisabled"
 fi
 
-connector --config /root/.connector/connector.conf $EXCHANGE_DISABLED_OPT \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec connector --config /root/.connector/connector.conf $EXCHANGE_DISABLED_OPT \
 --bitcoin.user=$BITCOIN_RPC_USER \
 --bitcoin.password=$BITCOIN_RPC_PASSWORD \
 --bitcoincash.user=$BITCOIN_CASH_RPC_USER \

--- a/docker/testnet/dash/Dockerfile
+++ b/docker/testnet/dash/Dockerfile
@@ -33,4 +33,6 @@ COPY dash.testnet.conf /root/default/dash.conf
 # starting dash daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/testnet/dash/entrypoint.sh
+++ b/docker/testnet/dash/entrypoint.sh
@@ -27,5 +27,7 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="-externalip=$EXTERNAL_IP"
 fi
 
-dashd $EXTERNAL_IP_OPT \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec dashd $EXTERNAL_IP_OPT \
 --rpcauth=$DASH_RPC_AUTH

--- a/docker/testnet/docker-compose.yml
+++ b/docker/testnet/docker-compose.yml
@@ -28,6 +28,9 @@ x-defaults:
   # Restart on exit.
   restart: always
 
+  # Wait for one minute for gracefull shutdown
+  stop_grace_period: 1m
+
 
 
 services:

--- a/docker/testnet/ethereum/Dockerfile
+++ b/docker/testnet/ethereum/Dockerfile
@@ -33,4 +33,6 @@ COPY ethereum.testnet.conf /root/default/ethereum.conf
 # starting bitcoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/testnet/ethereum/entrypoint.sh
+++ b/docker/testnet/ethereum/entrypoint.sh
@@ -35,7 +35,9 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="--nat extip:$EXTERNAL_IP"
 fi
 
-geth --rinkeby \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec geth --rinkeby \
 --datadir $DATA_DIR \
 --config $CONFIG \
 $EXTERNAL_IP_OPT

--- a/docker/testnet/litecoin/Dockerfile
+++ b/docker/testnet/litecoin/Dockerfile
@@ -33,4 +33,6 @@ COPY litecoin.testnet.conf /root/default/litecoin.conf
 # starting litecoin daemon.
 COPY entrypoint.sh /root/
 
-ENTRYPOINT bash /root/entrypoint.sh
+# We are using exec syntax to enable gracefull shutdown. Check
+# http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+ENTRYPOINT ["bash", "/root/entrypoint.sh"]

--- a/docker/testnet/litecoin/entrypoint.sh
+++ b/docker/testnet/litecoin/entrypoint.sh
@@ -27,5 +27,7 @@ if [ ! -z "$EXTERNAL_IP" ]; then
     EXTERNAL_IP_OPT="-externalip=$EXTERNAL_IP"
 fi
 
-litecoind $EXTERNAL_IP_OPT \
+# We are using `exec` to enable gracefull shutdown of running daemon.
+# Check http://veithen.github.io/2014/11/16/sigterm-propagation.html.
+exec litecoind $EXTERNAL_IP_OPT \
 --rpcauth=$LITECOIN_RPC_AUTH


### PR DESCRIPTION
Before during docker shutdowns containers SIGTERM signal doesn't
propagated to the daemons we run. This led to killing containers
after default 10s timeout which resulted to incorrect state of
blockchains and data loss. After restart blockchain daemons started
to syncing from old blocks (from months, even years ago).

Now exec method of runnging daemons used everywhere. Check
http://veithen.github.io/2014/11/16/sigterm-propagation.html for
more information.

Besides, gracefull shutdown limit of all containers are set to 1
minute.