### PR TITLE
docker/testnet: return original ports for btcd

### DIFF
--- a/docker/testnet/bitcoin-neutrino/Dockerfile
+++ b/docker/testnet/bitcoin-neutrino/Dockerfile
@@ -17,11 +17,8 @@ RUN go install -v . ./cmd/btcctl
 
 FROM ubuntu:18.04
 
-# RPC port.
-EXPOSE 13332
-
 # P2P port.
-EXPOSE 13333
+EXPOSE 18333
 
 # Copying required binaries from builder stage.
 COPY --from=builder /go/bin/btcd /go/bin/btcctl /usr/local/bin/

--- a/docker/testnet/bitcoin-neutrino/bitcoin-neutrino.testnet.conf
+++ b/docker/testnet/bitcoin-neutrino/bitcoin-neutrino.testnet.conf
@@ -2,9 +2,7 @@
 
 testnet=1
 
-rpclisten=0.0.0.0:13332
-
-listen=0.0.0.0:13333
+listen=0.0.0.0:18333
 
 addpeer=bitcoin.testnet:8333
 

--- a/docker/testnet/docker-compose.yml
+++ b/docker/testnet/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       # RPC port
       - "${PRIVATE_IP?PRIVATE_IP environment variable should be defined}:13332:13332"
       # P2P port
-      - "13333:13333"
+      - "18333:18333"
 
   bitcoin-cash.testnet:
     << : *defaults


### PR DESCRIPTION
Use 18333 port for P2P in `bitcoin-neutrino` service which is based on
`btcd`.

Do not expose RPC port. Leave accessible for local `btctl` only.